### PR TITLE
Replace "facebook" with "react-workspaces" in package.json files

### DIFF
--- a/packages/babel-plugin-named-asset-import/package.json
+++ b/packages/babel-plugin-named-asset-import/package.json
@@ -4,12 +4,12 @@
   "description": "Babel plugin for named asset imports in Create React App",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/babel-plugin-named-asset-import"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/react-workspaces/create-react-app/issues"
   },
   "main": "index.js",
   "files": [

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -4,12 +4,12 @@
   "description": "Babel preset used by Create React App",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/babel-preset-react-app"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/react-workspaces/create-react-app/issues"
   },
   "files": [
     "create.js",

--- a/packages/confusing-browser-globals/package.json
+++ b/packages/confusing-browser-globals/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/confusing-browser-globals"
   },
   "keywords": [

--- a/packages/cra-template-typescript/package.json
+++ b/packages/cra-template-typescript/package.json
@@ -11,7 +11,7 @@
   "main": "template.json",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/cra-template-typescript"
   },
   "license": "MIT",
@@ -19,7 +19,7 @@
     "node": ">=8.10"
   },
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/react-workspaces/create-react-app/issues"
   },
   "files": [
     "template",

--- a/packages/cra-template/package.json
+++ b/packages/cra-template/package.json
@@ -10,7 +10,7 @@
   "main": "template.json",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/cra-template"
   },
   "license": "MIT",
@@ -18,7 +18,7 @@
     "node": ">=8"
   },
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/react-workspaces/create-react-app/issues"
   },
   "files": [
     "template",

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -7,7 +7,7 @@
   "description": "Create React apps with no build configuration.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/create-react-app"
   },
   "license": "MIT",
@@ -15,7 +15,7 @@
     "node": ">=8"
   },
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/react-workspaces/create-react-app/issues"
   },
   "files": [
     "index.js",

--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -4,12 +4,12 @@
   "description": "ESLint configuration used by Create React App",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/eslint-config-react-app"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/react-workspaces/create-react-app/issues"
   },
   "files": [
     "index.js"

--- a/packages/react-app-polyfill/package.json
+++ b/packages/react-app-polyfill/package.json
@@ -4,12 +4,12 @@
   "description": "Polyfills for various browsers including commonly used language features",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/react-app-polyfill"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/react-workspaces/create-react-app/issues"
   },
   "engines": {
     "node": ">=6"

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -4,12 +4,12 @@
   "description": "Webpack utilities used by Create React App",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/react-dev-utils"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/react-workspaces/create-react-app/issues"
   },
   "engines": {
     "node": ">=8.10"

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -12,12 +12,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/react-workspaces/create-react-app.git",
     "directory": "packages/react-error-overlay"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/react-workspaces/create-react-app/issues"
   },
   "keywords": [
     "overlay",


### PR DESCRIPTION
I wanted to find this repo, so I went to your [npmjs page](https://www.npmjs.com/package/@react-workspaces/react-scripts). But I saw this:

<img width="412" alt="Capture d’écran 2020-01-12 à 19 20 58" src="https://user-images.githubusercontent.com/8782666/72222729-cd962580-3570-11ea-8c74-af7fcfbf5599.png">

This PR fixes the "homepage" and the "repository" URLs in all package.json files.