### PR TITLE
Set cwd to the workspace root for the webpack.config.js

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -62,6 +62,10 @@ const sassModuleRegex = /\.module\.(scss|sass)$/;
 
 const workspacesConfig = yarnWorkspaces.init(paths);
 
+// Change directory to the workspace root, to resolve file paths in relation
+// to the workspace. Useful for backtracking errors, in context of the workspace root!
+process.chdir(workspacesConfig.root);
+
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 module.exports = function(webpackEnv) {


### PR DESCRIPTION
Improves the developer experience, as file paths are correctly resolved via the root (allowing ctrl-clicking to directly open the file in question via the VSCode console)

Please test: I do not know what side effects this might have.

Before (no click-through):
![image](https://user-images.githubusercontent.com/837651/72540975-03455200-3882-11ea-9acd-d8eda381c6e6.png)



After:
![image](https://user-images.githubusercontent.com/837651/72540837-c9744b80-3881-11ea-8b59-32224d0cf676.png)
